### PR TITLE
allow configuring daemon heartbeat behavior

### DIFF
--- a/daemon/globus_cw_daemon/config.py
+++ b/daemon/globus_cw_daemon/config.py
@@ -24,10 +24,32 @@ def get_string(key):
     """
     Given a key returns the value of that key in config as a string.
     A KeyError will be raised if no constant with the given key exists.
-    A ValueError will be raised if the constant cannot be a string.
     """
     try:
-        value = _get_config().get("general", key)
-        return str(value)
-    except Exception:
+        return _get_config().get("general", key)
+    except configparser.NoOptionError:
+        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
+
+
+def get_bool(key):
+    """
+    Given a key returns the value of that key in config as a boolean.
+    A KeyError will be raised if no constant with the given key exists.
+    A ValueError will be raised if the constant cannot be a boolean.
+    """
+    try:
+        return _get_config().getboolean("general", key)
+    except configparser.NoOptionError:
+        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
+
+
+def get_int(key):
+    """
+    Given a key returns the value of that key in config as an int.
+    A KeyError will be raised if no constant with the given key exists.
+    A ValueError will be raised if the constant cannot be an int.
+    """
+    try:
+        return _get_config().getint("general", key)
+    except configparser.NoOptionError:
         raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))

--- a/daemon/globus_cw_daemon_install/default-config.ini
+++ b/daemon/globus_cw_daemon_install/default-config.ini
@@ -1,3 +1,5 @@
 [general]
 
 local_log_level = info
+heartbeats = True
+heartbeat_interval = 60

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,6 +3,15 @@
 
 #!/bin/bash
 
+# get a branch to test or default to master
+if [ $# -eq 1 ]
+then
+    branch=$1
+else
+    # default to master
+    branch="master"
+fi
+
 # cleanup any existing daemon or venv
 sudo rm -f /etc/systemd/system/globus_cw_daemon.service
 sudo rm -f /etc/cwlogd.ini
@@ -11,20 +20,20 @@ rm -rf venv
 set -e
 
 # setup the daemon as root
-sudo pip install git+https://github.com/globus/globus-cwlogger#subdirectory=daemon
-sudo globus_cw_daemon_install cwlogger-test --stream_name test-stream
+sudo pip install git+https://github.com/globus/globus-cwlogger@$branch#subdirectory=daemon
+sudo globus_cw_daemon_install cwlogger-test --stream-name test-stream
 sudo systemctl daemon-reload
 sudo service globus_cw_daemon restart
 sudo service globus_cw_daemon status
 
 # python 2 client test in venv
 virtualenv venv
-venv/bin/pip install git+https://github.com/globus/globus-cwlogger#subdirectory=client
+venv/bin/pip install git+https://github.com/globus/globus-cwlogger@$branch#subdirectory=client
 venv/bin/python client_test.py
 rm -rf venv
 
 # python 3 client test in venv
 virtualenv venv --python=python3
-venv/bin/pip install git+https://github.com/globus/globus-cwlogger#subdirectory=client
+venv/bin/pip install git+https://github.com/globus/globus-cwlogger@$branch#subdirectory=client
 venv/bin/python client_test.py
 rm -rf venv


### PR DESCRIPTION
Resolves #8 

The time between heartbeats can be up to around a second longer than the configured `heartbeat_interval`. If this is a problem I could have the daemon sleep shorter intervals or err on the side of sending heartbeats slightly more frequently than requested instead.