### PR TITLE
Adds GlobusSocketHandler log handler class

### DIFF
--- a/daemon/globus_cw_daemon/config.py
+++ b/daemon/globus_cw_daemon/config.py
@@ -1,55 +1,57 @@
 """
 Provides access to /etc/cwlogd.ini config values
 """
-import ConfigParser as configparser
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
 
 CONFIG_PATH = "/etc/cwlogd.ini"
-_config = None
+
+class Config(object):
+
+    def __init__(self, parser=None):
+        """
+        Either returns an already loaded configparser
+        Or creates a configparser and loads ini config at /etc/cwlogd.ini
+        """
+        if parser is None:
+            self._config = configparser.ConfigParser()
+            self._config.read(CONFIG_PATH)
+        else:
+            self._config = parser
 
 
-def _get_config():
-    """
-    Either returns an already loaded configparser
-    Or creates a configparser and loads ini config at /etc/cwlogd.ini
-    """
-    global _config
-    if _config is None:
-        _config = configparser.ConfigParser()
-        _config.read(CONFIG_PATH)
-
-    return _config
+    def get_string(self, key):
+        """
+        Given a key returns the value of that key in config as a string.
+        A KeyError will be raised if no constant with the given key exists.
+        """
+        try:
+            return self._config.get("general", key)
+        except configparser.NoOptionError:
+            raise KeyError("key {0!r} not found".format(key))
 
 
-def get_string(key):
-    """
-    Given a key returns the value of that key in config as a string.
-    A KeyError will be raised if no constant with the given key exists.
-    """
-    try:
-        return _get_config().get("general", key)
-    except configparser.NoOptionError:
-        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
+    def get_bool(self, key):
+        """
+        Given a key returns the value of that key in config as a boolean.
+        A KeyError will be raised if no constant with the given key exists.
+        A ValueError will be raised if the constant cannot be a boolean.
+        """
+        try:
+            return self._config.getboolean("general", key)
+        except configparser.NoOptionError:
+            raise KeyError("key {0!r} not found".format(key))
 
 
-def get_bool(key):
-    """
-    Given a key returns the value of that key in config as a boolean.
-    A KeyError will be raised if no constant with the given key exists.
-    A ValueError will be raised if the constant cannot be a boolean.
-    """
-    try:
-        return _get_config().getboolean("general", key)
-    except configparser.NoOptionError:
-        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
-
-
-def get_int(key):
-    """
-    Given a key returns the value of that key in config as an int.
-    A KeyError will be raised if no constant with the given key exists.
-    A ValueError will be raised if the constant cannot be an int.
-    """
-    try:
-        return _get_config().getint("general", key)
-    except configparser.NoOptionError:
-        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
+    def get_int(self, key):
+        """
+        Given a key returns the value of that key in config as an int.
+        A KeyError will be raised if no constant with the given key exists.
+        A ValueError will be raised if the constant cannot be an int.
+        """
+        try:
+            return self._config.getint("general", key)
+        except configparser.NoOptionError:
+            raise KeyError("key {0!r} not found".format(key))

--- a/log_handler/README.md
+++ b/log_handler/README.md
@@ -1,0 +1,75 @@
+# Globus CWLogger - Log Handler
+
+What is this?
+
+This a customized version of the Python [`logging.handlers.SocketHandler`](https://docs.python.org/3/library/logging.handlers.html#sockethandler)
+designed to send log records to the Globus CWLogger daemon for forwarding to Amazon CloudWatch.
+
+## Setup
+
+Install from Github:
+
+`pip install git+ssh://git@github.com/globus/globus-cwlogger.git@loghandler#egg=globus_cw_loghandler&subdirectory=log_handler`
+
+If the application using this log handler lives under a `globus.` package namespace, you will need to include following snippet
+in your `globus/__init__.py` so the two packages can co-exist under `globus`.
+
+
+```python
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+```
+
+[Refer to Python docs for more details.](https://docs.python.org/3/library/pkgutil.html#pkgutil.extend_path)
+
+## Usage
+
+For simple situations, this package includes a pre-configured instance you can just attach directly to a logger:
+
+```python
+import logging
+
+from globus.cwlogger import cloudwatch_handler
+
+log = logging.getLogger()
+log.addHandler(cloudwatch_handler)
+
+# This record will get sent to the CWLogger daemon.
+log.error("Something bad happened!")
+```
+
+In a more complex setup, it might be desirable to specify your logging in a JSON or a YAML config file and generate [a configuration dictionary.](https://docs.python.org/3/library/logging.config.html#logging-config-api)
+
+For example, something like:
+
+```yaml
+version: 1
+formatters:
+  myjson:
+    format: '{"time": "%(asctime)s", "logger_name": "%(name)s", "level": "%(levelname)s", "message": "%(message)s"}'
+  simple:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: simple
+    stream: ext://sys.stdout
+  cloudwatch:
+    class: globus.cwlogger.GlobusSocketHandler
+    formatter: myjson
+    host: '\0org.globus.cwlogs'
+loggers:
+  auditLogger:
+    level: INFO
+    handlers: [cloudwatch]
+    propagate: no
+root:
+  level: WARNING
+  handlers: [console, cloudwatch]
+
+
+```
+
+The important parameters here are the `class` and `host` that specifies a socket address where the CWLogger Daemon is listening.
+
+See the [Python Logging HOWTO for more information.](https://docs.python.org/3/howto/logging.html)

--- a/log_handler/globus/__init__.py
+++ b/log_handler/globus/__init__.py
@@ -1,0 +1,6 @@
+from pkgutil import extend_path
+# https://docs.python.org/2.7/library/pkgutil.html#pkgutil.extend_path
+# This lets us play nice and share the 'globus' import namespace with other
+# apps and libraries. Any other 'globus.*' apps should include this same
+# snippet.
+__path__ = extend_path(__path__, __name__)

--- a/log_handler/globus/cwlogger.py
+++ b/log_handler/globus/cwlogger.py
@@ -1,0 +1,129 @@
+import json
+import logging
+import logging.handlers
+import socket
+import sys
+import time
+
+try:
+    # Python 2
+    UNICODE_TYPE = unicode
+except NameError:
+    # Python 3
+    UNICODE_TYPE = str
+
+# Backports Python3 SocketHandler features that allow using UNIX sockets
+# instead of TCP sockets:
+
+
+class BackportedSocketHandler(logging.handlers.SocketHandler):
+
+    def __init__(self, host, port):
+        """
+        Backported from Python 3
+
+        Initializes the handler with a specific host address and port.
+        When the attribute *closeOnError* is set to True - if a socket error
+        occurs, the socket is silently closed and then reopened on the next
+        logging call.
+        """
+        logging.Handler.__init__(self)
+        self.host = host
+        self.port = port
+        if port is None:
+            self.address = host
+        else:
+            self.address = (host, port)
+        self.sock = None
+        self.closeOnError = False
+        self.retryTime = None
+        #
+        # Exponential backoff parameters.
+        #
+        self.retryStart = 1.0
+        self.retryMax = 30.0
+        self.retryFactor = 2.0
+
+    def makeSocket(self, timeout=1):
+        """
+        Backported from Python 3.
+
+        A factory method which allows subclasses to define the precise
+        type of socket they want.
+        """
+        if self.port is not None:
+            result = socket.create_connection(self.address, timeout=timeout)
+        else:
+            result = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            result.settimeout(timeout)
+            try:
+                result.connect(self.address)
+            except OSError:
+                result.close()  # Issue 19182
+                raise
+        return result
+
+
+if sys.version_info < (3, 4):
+    SocketHandlerBase = BackportedSocketHandler
+else:
+    SocketHandlerBase = logging.handlers.SocketHandler
+
+
+class GlobusSocketHandler(SocketHandlerBase):
+    """
+    Subclass of the Python SocketHandler that avoids
+    using pickle. Our Cloudwatch log daemon understands
+    JSON bytestrings, not binary pickles.
+    """
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Overrides the parent to call makePayload() instead of makePickle() and
+        also to close the socket once we've sent the record.
+
+        Serializes the record to JSON bytestring and writes it to the socket.
+        If there is an error with the socket, silently drop the packet.
+        If there was a problem with the socket, re-establishes the
+        socket.
+        """
+        try:
+            s = self.makePayload(record)
+            self.send(s)
+        except Exception:
+            self.handleError(record)
+        finally:
+            # Our daemon only uses the socket
+            # for one message, so we want to
+            # close here and get a new one next
+            # time.
+            self.close()
+
+    def makePayload(self, record):
+        """
+        Used in place of makePickle to generate a
+        JSON bytestring payload instead of a binary pickle.
+
+        Our cloudwatch daemon expects a JSON object
+        with keys 'timestamp' and 'message'.
+
+        'message' can also be another JSON string, depending
+        on what formatters you attach.
+        """
+
+        message = self.format(record)
+        payload = {
+            "message": message,
+            "timestamp": int(time.time() * 1000)
+        }
+        payload = json.dumps(payload,
+                             separators=(',', ':'),
+                             indent=None) + '\n'
+        if isinstance(payload, UNICODE_TYPE):
+            payload = payload.encode("utf-8")
+        return payload
+
+
+cloudwatch_handler = GlobusSocketHandler(host='\0org.globus.cwlogs', port=None)

--- a/log_handler/setup.py
+++ b/log_handler/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="globus_cw_loghandler",
+    version='0.1.0',
+    packages=find_packages(),
+
+    # descriptive info, non-critical
+    description="Python logging.SocketHandler customized for use with Globus CWLogger daemon.",
+    url="https://github.com/globus/globus-cwlogger",
+)

--- a/log_handler/test_requirements.txt
+++ b/log_handler/test_requirements.txt
@@ -1,0 +1,3 @@
+mock==2.0.0
+pytest==3.6.1
+git+ssh://git@github.com/bjmc-globus/globus-cwlogger.git@loghandler#egg=globus_cw_daemon&subdirectory=daemon

--- a/log_handler/tests/conftest.py
+++ b/log_handler/tests/conftest.py
@@ -1,0 +1,68 @@
+from collections import namedtuple
+from time import sleep
+import multiprocessing
+import logging
+import sys
+
+import pytest
+
+from globus_cw_daemon import daemon as cw_daemon
+from globus_cw_daemon.config import Config
+LogWriter = cw_daemon.cwlogs.LogWriter
+
+
+if sys.version_info[0] < 3:
+    import ConfigParser as configparser
+    from StringIO import StringIO
+    import mock
+else:
+    import configparser
+    from io import StringIO
+    from unittest import mock
+
+
+daemon_config = """
+[general]
+
+local_log_level = info
+heartbeats = False
+heartbeat_interval = 2
+stream_name = dummy_stream
+group_name = dummy_group
+"""
+testconfig = configparser.ConfigParser()
+testconfig.readfp(StringIO(daemon_config))
+
+DaemonFixture = namedtuple("DaemonFixture", 'events')
+
+
+@mock.patch('globus_cw_daemon.cwlogs.boto', mock.Mock())
+def fixture_daemon():
+    cw_daemon.main(Config(testconfig))
+
+
+@pytest.fixture(scope="session")
+def _daemon():
+    captured_events = multiprocessing.Queue()
+
+    def push_to_queue(self, events):
+        for evt in events:
+            captured_events.put(evt)
+
+    with mock.patch.object(LogWriter, 'upload_events', push_to_queue):
+        proc = multiprocessing.Process(target=fixture_daemon)
+        proc.start()
+        # Give it a little time to start up before yielding control
+        sleep(0.1)
+        yield DaemonFixture(captured_events)
+        proc.terminate()
+        proc.join()
+
+
+@pytest.fixture
+def daemon(_daemon):
+    # Clear any leftover events so we start fresh
+    # for each test.
+    while not _daemon.events.empty():
+        _daemon.events.get()
+    return _daemon

--- a/log_handler/tests/test_log_handler.py
+++ b/log_handler/tests/test_log_handler.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals
+
+import json
+from time import sleep
+import logging
+from globus.cwlogger import cloudwatch_handler, GlobusSocketHandler
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+log.addHandler(cloudwatch_handler)
+
+
+def _get_events(queue):
+    # Give the daemon flush thread time to catch up.
+    sleep(1)
+    events = []
+    while not queue.empty():
+        events.append(queue.get())
+    # Ordering is not guaranteed, sort by timestamp
+    events.sort(key=lambda evt: evt.timestamp)
+    return events
+
+
+def test_sending_string_events(daemon):
+    log.error("Test error.")
+    log.info("Test info.")
+    log.warn("Test warn.")
+    log.debug("Test debug.")
+    events = _get_events(daemon.events)
+    assert len(events) == 4
+    assert events[0].unicode_message == 'Test error.'
+    assert events[1].unicode_message == 'Test info.'
+    assert events[2].unicode_message == 'Test warn.'
+    assert events[3].unicode_message == 'Test debug.'
+
+
+def test_sending_json_events(daemon):
+    err = {'message': 'Test error.', 'id': 33, 'method': 'POST'}
+    log.error(json.dumps(err))
+    info = {'message': 'Ok', 'id': 12, 'method': 'GET'}
+    log.info(json.dumps(info))
+    events = _get_events(daemon.events)
+    assert len(events) == 2
+    assert json.loads(events[0].unicode_message) == err
+    assert json.loads(events[1].unicode_message) == info
+
+
+def test_sending_traceback(daemon):
+    try:
+        5 / 0
+    except ZeroDivisionError as exc:
+        log.exception(exc)
+    events = _get_events(daemon.events)
+    assert len(events) == 1
+    assert len(events[0].unicode_message.splitlines()) == 5

--- a/log_handler/tox.ini
+++ b/log_handler/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py34,py35,py36
+
+[testenv]
+deps = pytest
+       mock
+       git+ssh://git@github.com/bjmc-globus/globus-cwlogger.git@loghandler#egg=globus_cw_daemon&subdirectory=daemon
+       .
+commands = pytest {posargs}


### PR DESCRIPTION
This adds a `GlobusSocketHandler` class as an alternative client to the CWLogger daemon for situations where it's desirable to attach new handlers to an existing Python logging setup.

There are also minor changes to the daemon code to make it run under Python 3 and make it easier to pass in custom test config. 