### PR TITLE
Make sure connection error is in scope when re-raising

### DIFF
--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -51,12 +51,12 @@ def _connect(retries, wait):
         try:
             sock.connect(addr)
         except Exception as err:
-            pass
+            error = err
         else:
             return sock
         time.sleep(wait)  # seconds
 
-    raise CWLoggerConnectionError("couldn't connect to cw", err)
+    raise CWLoggerConnectionError("couldn't connect to cw", error)
 
 
 def _request(req, retries, wait):

--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -1,7 +1,9 @@
 """
 Python client API for cwlogs daemon
 """
-import time, socket, json
+import time
+import socket
+import json
 
 try:
     # Python 2
@@ -89,9 +91,13 @@ def _request(req, retries, wait):
 
 
 # Ignore (swallow) these exceptions at your own risk.
-# CWLoggerDaemonError can be caused by many things, including but not limited to: bad IAM policy, a killed / failed daemon background thread, AWS throttling, invalid length/encoding.
-# Ignore only if you have some other mechanism (e.g. a lambda / cloudwatch / heartbeat monitor) to ensure logs are properly configured and working, and/or write logs to disk manually.
-# Note that even in the absence of exceptions, messages may still be lost - the daemon has a very large memory queue and works asynchronously.
+# CWLoggerDaemonError can be caused by many things, including but not limited to:
+# bad IAM policy, a killed / failed daemon background thread, AWS throttling,
+# invalid length/encoding.
+# Ignore only if you have some other mechanism (e.g. a lambda / cloudwatch / heartbeat monitor)
+# to ensure logs are properly configured and working, and/or write logs to disk manually.
+# Note that even in the absence of exceptions, messages may still be lost - the daemon has a
+# very large memory queue and works asynchronously.
 
 
 class CWLoggerError(Exception):


### PR DESCRIPTION
The variable scope rules have changed slightly in Python3.

For instance, this works in Python2:

```python
try:
    raise ValueError("oh no")
except ValueError as err:
    pass
print(err)
```

But it will fail with `NameError: name 'err' is not defined` in Python3.

This fixes that glitch to be Python3-compatible, and also includes some cosmetic changes to satisfy flake8.