### PR TITLE
Show queue fullness in daemon responses, client responses, and heartbeats

### DIFF
--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -36,7 +36,7 @@ def log_event(message, retries=10, wait=0.1):
     req = dict()
     req["message"] = message
     req["timestamp"] = int(time.time() * 1000)
-    _request(req, retries, wait)
+    return _request(req, retries, wait)
 
 
 def _connect(retries, wait):
@@ -81,7 +81,7 @@ def _request(req, retries, wait):
     if isinstance(d, dict):
         status = d["status"]
         if status == "ok":
-            return
+            return d
         else:
             raise CWLoggerDaemonError("forwarded error", d["message"])
     else:

--- a/daemon/globus_cw_daemon/daemon.py
+++ b/daemon/globus_cw_daemon/daemon.py
@@ -93,27 +93,22 @@ def _get_drop_event(nr_dropped):
     return ret
 
 
-def _get_heartbeat_event():
-    data = dict(type="audit", subtype="cwlogs.heartbeat",
-                instance_id=INSTANCE_ID)
-    ret = cwlogs.Event(timestamp=None, message=json.dumps(data))
-    return ret
-
-
 def _health_info():
     """
     compute daemon health info
     based only on the visible state of the frontend queue
     """
     q_len = len(_g_queue)  # no lock, but safe
-    q_pct = q_len / float(MAX_EVENT_QUEUE_LEN)
-    health_color = "green"
-    if q_pct > 0.7:
-        health_color = "red"
-    elif q_pct > 0.5:
-        health_color = "yellow"
-    return dict(queue_length=q_len, queue_percent_full=q_pct,
-                status=health_color)
+    q_pct = (q_len / float(MAX_EVENT_QUEUE_LEN)) * 100
+    return dict(queue_length=q_len, queue_percent_full=q_pct)
+
+
+def _get_heartbeat_event():
+    data = dict(type="audit", subtype="cwlogs.heartbeat",
+                instance_id=INSTANCE_ID,
+                health=_health_info())
+    ret = cwlogs.Event(timestamp=None, message=json.dumps(data))
+    return ret
 
 
 def do_request(sock):


### PR DESCRIPTION
Add queue fullness (queue length and percent full) to the heartbeats and client responses under the key `health`. This can be expanded with other health metric or diagnostic info in the future.

Update the client to return the daemon's payload (when status=ok).
Queue percent full will start flowing back to clients as the result of their log_event() calls.

Only examines the frontend queue, as the backend queue is not easily visible. The backend queue is not refilled if its past flush is not complete, so it's not as important to monitor as the frontend queue.

We discussed the pros and cons of using a LogMetric for queue full %, but the easiest option for this product is to expose the information in both places and let consumers decide how they want to process that info.