### PR TITLE
Add CONTRIBUTING doc, CODEOWNERS, tweak README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS reference:
+#   https://help.github.com/en/articles/about-code-owners
+#
+# sirosen, aaschaer are the current project maintainers, so they should be made
+# "owners" on all files
+* @sirosen, @aaschaer

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,42 @@
+Contributing to globus-cwlogger
+===============================
+
+Guidelines
+----------
+
+- Maintaining a stable client and server is our primary goal, so we favor
+  carefully planned changes and slow releases
+
+- We are conservative with the featureset we offer
+
+- The daemon only supports one python version (currently python2, will switch
+  to python3)
+
+- The client supports both python2 and python3 until at least python2 EOL
+
+Linting & Testing
+-----------------
+
+- No linting is currently setup, but we are considering adding `flake8`,
+  `black`, and `isort` to our requirements.
+
+- "Simulated" automated testing (e.g. with a mocked cwlogs API) is not a
+  priority for this project
+
+  - We want to test in the realistic context of a server running the daemon,
+    writing to cwlogs
+
+  - Lacking mock-based unit-tests does not reflect a lack of investment in
+    testing -- enhancements to the testing tools are very much welcome!
+
+NOTE: Please do not reformat code cosmetically without discussing it
+beforehand. We do want to apply some code checkers and fixers, but as part of
+a carefully considered effort.
+
+
+Running a Release
+-----------------
+
+- Update the changelog to reflect the latest released version.
+- Cut a release branch (e.g. `release/beta-4`)
+- Notify via email that there's a new release, link to latest changelog

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,10 @@
-= globus-cloudwatch-logger
+= globus-cwlogger
 
-Tool for globus services to log to aws cloudwatch
+globus-cwlogger is a simple client and daemon for writing log data to
+AWS CloudWatch Logs as an alternative to the AWS CloudWatch Agent.
 
-Maintainers: aaschaer, sirosen
+Although globus-cwlogger is an open source project, it is not intended for
+general use. We don't recommend that third parties depend upon it.
 
 ==== Install, enable, and restart Daemon (Python 2)
 


### PR DESCRIPTION
closes #22

- try out a CODEOWNERS file to auto-assign PRs for review

This can also be used to do enforcement, but we should try it a bit (and get it working!) before we try out those features.

- Add a contributing doc

Covers linting and code standards in short order, and documents the release process.

- Update the README

Part of the point of CODEOWNERS is to declare maintainers, so we can drop that line from the readme.

While in there, I also wanted to clarify what this is and what our posture is towards 3rd party use. I borrowed language from BoringSSL's readme for this, which has a similar "internal, but open source" mode of use.