### PR TITLE
Tune logging to be more syslog-friendly

### DIFF
--- a/daemon/globus_cw_daemon/cwlogs.py
+++ b/daemon/globus_cw_daemon/cwlogs.py
@@ -132,8 +132,8 @@ class LogWriter(object):
                     break
                 events.pop()
 
-            _log.info("flushing batch, bytes=%d, recs=%d",
-                    batch.nr_bytes, len(batch.records))
+            _log.debug("flushing batch, bytes=%d, recs=%d",
+                       batch.nr_bytes, len(batch.records))
             self._flush_events(batch.get_records_for_boto())
 
 

--- a/daemon/globus_cw_daemon/cwlogs.py
+++ b/daemon/globus_cw_daemon/cwlogs.py
@@ -149,7 +149,7 @@ class LogWriter(object):
                         self.stream_name, 
                         events, 
                         sequence_token=self.sequence_token)
-                _log.info("flush ok")
+                _log.debug("flush ok")
                 self.sequence_token = ret["nextSequenceToken"]
                 #raise Exception("test")
                 return

--- a/daemon/globus_cw_daemon/local_logging.py
+++ b/daemon/globus_cw_daemon/local_logging.py
@@ -1,0 +1,72 @@
+import logging
+import logging.config
+
+import globus_cw_daemon.config as config
+
+
+class PrintKFormatter(logging.Formatter):
+    """
+    a formatter which encodes log levels in the way expected by syslog
+    and journald -- adds the following prefixes for each level
+      DEBUG:   "<7>"
+      INFO:    "<6>"
+      NOTICE : "<5>"
+      WARNING: "<4>"
+      ERR:     "<3>"
+      CRIT:    "<2>"
+      ALERT:   "<1>"
+      EMERG:   "<0>"
+
+    Note that these numeric values *don't* match the numeric values used by
+    python for its log levels.
+
+    This is called "PrintK" because this entire system of logging takes its
+    inspiration from the printk() kernel logging facilities.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs["fmt"] = (
+            "%(asctime)s.%(msecs)03d %(levelname)s %(process)d:%(thread)d "
+            "%(name)s: %(message)s"
+        )
+        kwargs["datefmt"] = "%Y-%m-%d %H:%M:%S"
+        super(PrintKFormatter, self).__init__(*args, **kwargs)
+
+    def encode_level(self, record):
+        # logging.handlers.SyslogHandler has an interesting note about
+        # "INFO".lower() != "info" in certain locales...
+        # so this is technically safer than `.lower()`, not that it's likely to
+        # ever matter
+        mapped_log_level = {
+            "DEBUG": "debug",
+            "INFO": "info",
+            "WARNING": "warning",
+            "ERROR": "error",
+            "CRITICAL": "critical",
+        }.get(record.levelname, "warning")
+
+        return {"critical": 2, "error": 3, "warning": 4, "info": 6, "debug": 7}[
+            mapped_log_level
+        ]
+
+    def format(self, record):
+        level = "<{}>".format(self.encode_level(record))
+        return level + super(PrintKFormatter, self).format(record)
+
+
+def configure():
+    """
+    configure the globus_cw_daemon logger to write to stderr,
+
+    Set up a stderr StreamHandler, PrintKFormatter, and log level pulled from
+    config
+    """
+    logger = logging.getLogger('globus_cw_daemon')
+
+    handler = logging.StreamHandler()
+    formatter = PrintKFormatter()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    local_log_level = config.get_string("local_log_level").upper()
+    logger.setLevel(local_log_level)

--- a/daemon/globus_cw_daemon_install/example-journald.conf
+++ b/daemon/globus_cw_daemon_install/example-journald.conf
@@ -1,0 +1,13 @@
+# this is an example config, use or modify to suit your needs
+#
+# this is a systemd-journald config file which specifies that DEBUG messages
+# should not be forwarded to Syslog
+# this is beneficial when you want globus_cw_logger debugging to be visible in
+# the journal, but not in syslog
+#
+# when placed in /etc/systemd/journald.conf.d/*.conf
+# and loaded by journald (e.g. `systemctl force-reload systemd-journald`), it
+# will take effect
+
+[Journal]
+MaxLevelSyslog=6

--- a/test/_install_daemon.sh
+++ b/test/_install_daemon.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# get a branch to test or default to master
+if [ $# -eq 1 ]
+then
+    branch=$1
+else
+    # default to master
+    branch="master"
+fi
+
+# cleanup any existing daemon or venv
+sudo rm -f /etc/systemd/system/globus_cw_daemon.service
+sudo rm -f /etc/cwlogd.ini
+sudo pip uninstall globus_cw_daemon -y
+rm -rf venv
+set -e
+
+# setup the daemon as root
+sudo pip install git+https://github.com/globus/globus-cwlogger@$branch#subdirectory=daemon
+sudo globus_cw_daemon_install cwlogger-test --stream-name test-stream
+sudo systemctl daemon-reload
+sudo service globus_cw_daemon restart
+sudo service globus_cw_daemon status

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,6 +3,8 @@
 
 #!/bin/bash
 
+cd "$(dirname "$0")"
+
 # get a branch to test or default to master
 if [ $# -eq 1 ]
 then
@@ -12,19 +14,8 @@ else
     branch="master"
 fi
 
-# cleanup any existing daemon or venv
-sudo rm -f /etc/systemd/system/globus_cw_daemon.service
-sudo rm -f /etc/cwlogd.ini
-sudo pip uninstall globus_cw_daemon -y
-rm -rf venv
-set -e
-
-# setup the daemon as root
-sudo pip install git+https://github.com/globus/globus-cwlogger@$branch#subdirectory=daemon
-sudo globus_cw_daemon_install cwlogger-test --stream-name test-stream
-sudo systemctl daemon-reload
-sudo service globus_cw_daemon restart
-sudo service globus_cw_daemon status
+# cleanup any existing daemon or venv and (re)install as root
+./_install_daemon.sh "$@"
 
 # run client_test.py with python2
 virtualenv venv


### PR DESCRIPTION
Closes #31.

We shouldn't rush this -- I've only tested it a bit on a single server, and I think I need more time with it -- but I wanted to open it up for review and more testing hands at this point.

Basically, I've tried turning several statements down to DEBUG, and then putting in the necessary work so that you could turn DEBUG logging _on_ but not flood your syslog data.

To test, I turned on daemon facility logs in my rsyslog config like so:
```
# in /etc/rsyslog.d/50-default.conf for me
daemon.*            -/var/log/daemon.log
```

And set the example journald config.

Finally, tweak `/etc/cwlogd.ini` to set the local log level to DEBUG and restart the service.

The result is that `journalctl -u globus_cw_daemon.service` shows the debug logs, but `tail -f /var/log/daemon.log` only shows info logs.

---

The `PrintKFormatter` is just mapping python log levels to syslog priority levels and prefixing them.
The thing which may be surprising/unintuitive (it confused me, at least) is that journald seems to consume the prefix and _not_ preserve it when echoing. So your logs will appear without the `<6>` prefix, but it was really emitted that way to stderr (and you can prove it to yourself with some debug printing).

In terms of the logging config setup, I did try to use basicConfig and dictConfig, but neither of these worked well for various reasons. Rather than fighting to use those tools, just doing imperative logging config seems fine.

As an additional tweak included here, I've split out the daemon install from the rest of the test script. The reason is simply that to iterate, I wanted to setup an instance and then update the system install without waiting for the full test script. It's not important, but also sufficiently small/harmless a change that I included it.