### PR TITLE
Add pre-commit configuration for running hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 __pycache__/
 *.pyc
 *.egg-info/
+.mypy_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,9 +32,7 @@ repos:
     - id: bandit
       name: "Check for common python security issues"
       types: [python]
-      # skip certain rules:
-      #   B101 checks for 'assert' which can be removed when code is optimized
-      args: ["-s", "B101"]
+      exclude: ^test/.*$
       language_version: python3
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.720

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,59 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  rev: v0.9.1
+  hooks:
+    - id: check-merge-conflict
+    - id: trailing-whitespace
+- repo: https://github.com/python/black
+  rev: 19.3b0
+  hooks:
+    - id: black
+      name: "Autoformat python files"
+      types: [python]
+      language_version: python3
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.8
+  hooks:
+    - id: flake8
+      name: "Lint python files"
+      types: [python]
+      language_version: python3
+      additional_dependencies: ['flake8-bugbear==19.3.0']
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21
+  hooks:
+    - id: isort
+      name: "Sort python imports"
+      types: [python]
+      language_version: python3
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.6.2
+  hooks:
+    - id: bandit
+      name: "Check for common python security issues"
+      types: [python]
+      # skip certain rules:
+      #   B101 checks for 'assert' which can be removed when code is optimized
+      args: ["-s", "B101"]
+      language_version: python3
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.720
+  hooks:
+    - id: mypy
+      name: "Type-check client"
+      files: client/.*$
+      types: [python]
+      args: ["--py2"]
+      language_version: python3
+    - id: mypy
+      name: "Type-check daemon"
+      files: daemon/.*$
+      types: [python]
+      language_version: python3
+- repo: local
+  hooks:
+    - id: shellcheck
+      name: "Lint shell scripts"
+      entry: shellcheck
+      language: system
+      types: [shell]

--- a/Makefile
+++ b/Makefile
@@ -4,28 +4,17 @@ help:
 	@echo ""
 	@echo "  help:      Show this helptext"
 	@echo ""
-	@echo "  autoformat:"
-	@echo "             run autoformatting tools"
-	@echo ""
-	@echo "  lint:      run autoformatting tools as linters + flake8"
+	@echo "  lint:      run linters and fixers"
 	@echo ""
 	@echo "  clean:     remove tooling virtualenv"
 
 .venv:
 	python3 -m venv .venv
-	.venv/bin/pip install black isort flake8
-	touch .venv
-
-.PHONY: autoformat
-autoformat: .venv
-	 .venv/bin/isort --recursive .
-	 .venv/bin/black .
+	.venv/bin/pip install pre-commit==1.18.3
 
 .PHONY: lint
 lint: .venv
-	.venv/bin/isort --check-only --recursive .
-	.venv/bin/black --check .
-	.venv/bin/flake8
+	.venv/bin/pre-commit run --all-files --show-diff-on-failure
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 
 .PHONY: lint
 lint: .venv
-	.venv/bin/pre-commit run --all-files --show-diff-on-failure
+	.venv/bin/pre-commit run --all-files
 
 .PHONY: clean
 clean:

--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -13,6 +13,11 @@ except NameError:
     UNICODE_TYPE = str  # type: ignore
 
 
+def _checktype(value, types, message):
+    if not isinstance(value, types):
+        raise TypeError(message)
+
+
 def log_event(message, retries=10, wait=0.1):
     """
     Log the @message string to cloudwatch logs, using the current time.
@@ -27,13 +32,15 @@ def log_event(message, retries=10, wait=0.1):
     # python3 json library can't handle bytes, so preemptively decode utf-8
     if isinstance(message, bytes):
         message = message.decode("utf-8")
-    assert isinstance(message, UNICODE_TYPE)
+    _checktype(message, UNICODE_TYPE, "message type must be bytes or unicode")
 
-    assert type(retries) == int
-    assert retries >= 0
+    _checktype(retries, int, "retries must be an int")
+    if retries < 0:
+        raise ValueError("retries must be non-negative")
 
-    assert type(wait) == int or type(wait) == float
-    assert wait >= 0
+    _checktype(wait, (int, float), "wait must be an int or float")
+    if wait < 0:
+        raise ValueError("wait must be non-negative")
 
     req = dict()
     req["message"] = message

--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -7,10 +7,10 @@ import time
 
 try:
     # Python 2
-    UNICODE_TYPE = unicode
+    UNICODE_TYPE = unicode  # type: ignore
 except NameError:
     # Python 3
-    UNICODE_TYPE = str
+    UNICODE_TYPE = str  # type: ignore
 
 
 def log_event(message, retries=10, wait=0.1):
@@ -48,7 +48,7 @@ def _connect(retries, wait):
     Raise: Exception if max attempts exceeded
     """
     addr = "\0org.globus.cwlogs"
-    for i in range(retries + 1):
+    for _ in range(retries + 1):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, 0)
         try:
             sock.connect(addr)

--- a/daemon/globus_cw_daemon/daemon.py
+++ b/daemon/globus_cw_daemon/daemon.py
@@ -10,6 +10,7 @@ import socket
 import sys
 import threading
 import time
+import typing
 
 import globus_cw_daemon.config as config
 import globus_cw_daemon.cwlogs as cwlogs
@@ -31,12 +32,14 @@ _log = logging.getLogger(__name__)
 
 # Data shared with flush thread
 _g_lock = threading.Lock()
-_g_queue = []  # List of Events
+_g_queue: typing.List[cwlogs.Event] = []  # List of Events
 _g_nr_dropped = 0
 
 # get constant instance_id on start
 try:
-    INSTANCE_ID = os.readlink("/var/lib/cloud/instance").split("/")[-1]
+    INSTANCE_ID: typing.Union[str, None] = os.readlink("/var/lib/cloud/instance").split(
+        "/"
+    )[-1]
 except OSError:
     INSTANCE_ID = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,7 @@ max-line-length = 88
 # ref: https://github.com/ambv/black/blob/master/.flake8
 # W503/W504 conflict, black causes E203
 ignore = W503,W504,E203,
+
+
+[mypy]
+ignore_missing_imports = true

--- a/test/README
+++ b/test/README
@@ -1,6 +1,6 @@
 Run `bash test.sh` on a machine that has pip, python2, and python3,
 and is configured with aws permissions to an existing cloudwatch group named
-"cwlogger-test" 
+"cwlogger-test"
 
 Tests the following:
 - download from github via pip


### PR DESCRIPTION
`make lint` now uses [pre-commit](https://pre-commit.com/) to run all hooks on all files.
`make autoformat` is no longer needed since the fixers fail but make changes when there is unformatted code. So `make lint` can be used to run formatters in a pinch.

Hooks
- check for merge conflict strings in files
- check for and remove all trailing whitespace
- black format all python
- isort all python
- flake8 + flake8-bugbear all python
- mypy lint client and daemon libs separately, to avoid certain spurious conflicts and use `--py2` on client
- bandit security linting for all python

Additionally, some very minor tweaks to pass lints:
- remove trailing whitespace from test readme
- add type annotations where mypy demands it

-----

@aaschaer, I'd like you to try out `make clean lint` before merging this and make sure that (1) it works for you and (2) you're satisfied with the results.

It should show you a "pretty" report like so:
![Screenshot 2019-09-12 at 7 19 07 PM](https://user-images.githubusercontent.com/1300022/64827933-7c5f3080-d594-11e9-9c5a-4712fb3256f2.png)

If you want to try out the pre-commit integration -- purely optional -- you'll need to do a user-install of `pre-commit` (i.e. `pip install --user pre-commit`) and then run `pre-commit install` from your clone of the repo.

I'm considering putting forth this tooling for the SDK and CLI as well, so globus-cwlogger is acting as a little bit of a guinea pig. I'm happy to talk here or elsewhere about this and hear your thoughts.