### PR TITLE
Add a script for uploading sdists as release assets to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyc
 *.egg-info/
 .mypy_cache/
+*.tar.gz

--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ sudo systemctl start globus_cw_daemon
 ==== Install and use Client Module (Python 2 or 3)
 
 ----
-pip install git+https://github.com/globus/globus-cwlogger1.0#subdirectory=client&egg=globus_cw_client
+pip install git+https://github.com/globus/globus-cwlogger@1.0#subdirectory=client&egg=globus_cw_client
 ----
 
 ----
@@ -30,4 +30,22 @@ log_event("some message string")
 # default is retries=10, wait=0.1
 log_event("message which fails fast", retries=0, wait=0)
 log_event("message which waits up to 60 seconds", retries=60, wait=1)
+----
+
+=== Installation Without `subdirectory`
+
+If you are using a non-pip tool to handle python packages, it may not support
+`subdirectory`. In these cases, it's best to use the published sdist tarballs
+for each release.
+
+Daemon:
+
+----
+sudo pip3 install https://github.com/globus/globus-cwlogger/releases/download/1.0/daemon.tar.gz
+----
+
+Client:
+
+----
+pip install https://github.com/globus/globus-cwlogger/releases/download/1.0/client.tar.gz
 ----

--- a/publish-github-assets.sh
+++ b/publish-github-assets.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+GHAPI="https://api.github.com"
+GHUPLOADS="https://uploads.github.com"
+REPO_PATH="repos/globus/globus-cwlogger"
+
+echo "= Startup & Self-Check"
+
+command -v jq > /dev/null 2>&1 || { echo "requires jq"; exit 2; }
+
+RELEASE_PATH="latest"
+[ $# -gt 0 ] && RELEASE_PATH="tags/$1"
+[ -f "$HOME/.github-token" ] || { echo "Must have a token in ~/.github-token"; exit 2; }
+
+AUTH_H="Authorization: token $(cat "$HOME"/.github-token)"
+RELEASE_ID="$(curl -s -H "$AUTH_H" "${GHAPI}/$REPO_PATH/releases/$RELEASE_PATH" | jq '.id' -r)"
+echo "RELEASE_ID=$RELEASE_ID"
+
+ASSET_URL="$GHUPLOADS/$REPO_PATH/releases/$RELEASE_ID/assets"
+echo "ASSET_URL=$ASSET_URL"
+
+# build and upload client and daemon packages
+for name in client daemon; do
+  pushd "$name"
+  echo "= $name = Clean any past run"
+  rm -rf ./dist/
+  rm -f ./$name.tar.gz
+
+  echo "= $name = Build"
+  python setup.py sdist
+  glob=(dist/*.tar.gz)
+  TARBALL="${glob[0]}"
+  echo "TARBALL=$TARBALL"
+
+  echo "= $name = Rename"
+  mv "$TARBALL" "$name.tar.gz"
+
+  echo "= $name = Upload"
+  curl -Ssf -XPOST \
+      -H "Authorization: token $(cat "$HOME"/.github-token)" \
+      -H "Content-Type: application/gzip" \
+      "${ASSET_URL}?name=$name.tar.gz" --data-binary @"$name.tar.gz"
+  popd
+done


### PR DESCRIPTION
I was tinkering with Poetry and found that it doesn't have support for the `subdirectory` directive.
I think pip-tools and pipenv also have issues with the way we specify things.

I hacked up a *very* simple script which builds and uploads `client.tar.gz` and `daemon.tar.gz` to GitHub releases as a workaround, and put builds on the 1.0 release to test.
I was then able to `poetry add 'https://github.com/globus/globus-cwlogger/releases/download/1.0/client.tar.gz'`, which is basically all I needed.

I think it costs us very little to run this each release. You just need to keep a GitHub personal access token around (I already do, personally).
If you want to fancy-up this script and give it helptext, let it take the GitHub token from an env var, etc. I'm happy to extend it within reason -- I just want it to stay small and simple.