### PR TITLE
Update to support the use of EMF logs

### DIFF
--- a/Changelog.adoc
+++ b/Changelog.adoc
@@ -1,5 +1,9 @@
 = GLOBUS CW-LOGGER Changelog
 
+== Unreleased
+
+* add support for EMF-format logs
+
 == 1.0
 
 * convert the daemon to python3-only -- the client is still py2/py3

--- a/README.adoc
+++ b/README.adoc
@@ -49,3 +49,24 @@ Client:
 ----
 pip install https://github.com/globus/globus-cwlogger/releases/download/1.0/client.tar.gz
 ----
+
+=== Using EMF Logs
+
+globus-cwlogger supports use of the CloudWatch Embedded Metric Format.
+For full details, see
+link:https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html[the EMF specification].
+
+Logging with EMF does not require any special options or considerations. For
+example, this log will create a metric `foo` with a dimension
+`bar='test-metric'`:
+
+----
+import json
+import time
+
+from globus_cw_client.client import log_event
+
+
+payload = {"foo": 1, "bar": "test-metric", "_aws": {"Timestamp": int(time.time()*1000), "CloudWatchMetrics": [{"Namespace": "globus-cwlogger-test", "Dimensions": [["bar"]], "Metrics": [{"Name": "foo", "Unit": "Count"}]}]}}
+log_event(json.dumps(payload))
+----

--- a/daemon/globus_cw_daemon/cwlogs.py
+++ b/daemon/globus_cw_daemon/cwlogs.py
@@ -27,6 +27,10 @@ def _checktype(value, types, message):
         raise TypeError(message)
 
 
+def _add_emf_header(request, **kwargs):
+    request.headers.add_header("x-amzn-logs-format", "json/emf")
+
+
 class Event(object):
     def __init__(self, timestamp, message, enforce_limit=True):
         """
@@ -102,6 +106,9 @@ class LogWriter(object):
         # Keep a connection around for performance.  boto is smart enough
         # to refresh role creds right before they expire (see provider.py).
         self.client = boto3.client("logs", region_name=(aws_region or "us-east-1"))
+        self.client.meta.events.register(
+            "before-sign.cloudwatch-logs.PutLogEvents", _add_emf_header
+        )
 
         self.group_name = group_name
         self.stream_name = stream_name


### PR DESCRIPTION
The `json/emf` format header is now attached to all calls. This is non-harmful for non-EMF logs, and allows any JSON logs which are EMF-formatted to be interpreted.

An example in the readme details how to use EMF with a complete, minimal example.

---

@aaschaer, two quick things:
1. I renamed `master` to `main`. I assume that's no biggie, but heads up.
2. Other than this, I'd like to update the client to be python3-only (since we shouldn't have any remaining py2 clients to support). After that, I'd release the result as "version 1.1".