### PR TITLE
Drop python2 support from client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,57 +1,57 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v0.9.1
+  rev: v3.4.0
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/python/black
-  rev: 19.3b0
+  rev: 21.5b1
   hooks:
     - id: black
-      name: "Autoformat python files"
       types: [python]
       language_version: python3
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.8
+  rev: 3.9.2
   hooks:
     - id: flake8
-      name: "Lint python files"
       types: [python]
       language_version: python3
-      additional_dependencies: ['flake8-bugbear==19.3.0']
+      additional_dependencies: ['flake8-bugbear==20.11.1']
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.15.0
+  hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]
 - repo: https://github.com/timothycrosley/isort
-  rev: 4.3.21
+  rev: 5.8.0
   hooks:
     - id: isort
-      name: "Sort python imports"
       types: [python]
       language_version: python3
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.6.2
+  rev: 1.7.0
   hooks:
     - id: bandit
-      name: "Check for common python security issues"
       types: [python]
       exclude: ^test/.*$
       language_version: python3
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.720
+  rev: v0.812
   hooks:
     - id: mypy
-      name: "Type-check client"
+      name: "mypy client/"
       files: client/.*$
       types: [python]
-      args: ["--py2"]
       language_version: python3
     - id: mypy
-      name: "Type-check daemon"
+      name: "mypy daemon/"
       files: daemon/.*$
       types: [python]
       language_version: python3
 - repo: local
   hooks:
     - id: shellcheck
-      name: "Lint shell scripts"
+      name: "shellcheck"
       entry: shellcheck
       language: system
       types: [shell]

--- a/Changelog.adoc
+++ b/Changelog.adoc
@@ -2,6 +2,8 @@
 
 == Unreleased
 
+* Drop client support for python2
+
 == 1.1b1
 
 * add support for EMF-format logs

--- a/README.adoc
+++ b/README.adoc
@@ -6,16 +6,16 @@ AWS CloudWatch Logs as an alternative to the AWS CloudWatch Agent.
 Although globus-cwlogger is an open source project, it is not intended for
 general use. We don't recommend that third parties depend upon it.
 
-==== Install, enable, and restart Daemon (Python 3)
+==== Install, enable, and restart Daemon
 
 ----
-sudo pip3 install git+https://github.com/globus/globus-cwlogger@1.0#subdirectory=daemon&egg=globus_cw_daemon
+sudo pip install git+https://github.com/globus/globus-cwlogger@1.0#subdirectory=daemon&egg=globus_cw_daemon
 sudo globus_cw_daemon_install <group_name> --stream-name <optional_stream_name>
 sudo systemctl -q enable globus_cw_daemon.service
 sudo systemctl start globus_cw_daemon
 ----
 
-==== Install and use Client Module (Python 2 or 3)
+==== Install and use Client Module
 
 ----
 pip install git+https://github.com/globus/globus-cwlogger@1.0#subdirectory=client&egg=globus_cw_client

--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,8 @@ AWS CloudWatch Logs as an alternative to the AWS CloudWatch Agent.
 Although globus-cwlogger is an open source project, it is not intended for
 general use. We don't recommend that third parties depend upon it.
 
+Requires python3.6+
+
 ==== Install, enable, and restart Daemon
 
 ----

--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -5,13 +5,6 @@ import json
 import socket
 import time
 
-try:
-    # Python 2
-    UNICODE_TYPE = unicode  # type: ignore
-except NameError:
-    # Python 3
-    UNICODE_TYPE = str  # type: ignore
-
 
 def _checktype(value, types, message):
     if not isinstance(value, types):
@@ -32,7 +25,7 @@ def log_event(message, retries=10, wait=0.1):
     # python3 json library can't handle bytes, so preemptively decode utf-8
     if isinstance(message, bytes):
         message = message.decode("utf-8")
-    _checktype(message, UNICODE_TYPE, "message type must be bytes or unicode")
+    _checktype(message, str, "message type must be bytes or unicode")
 
     _checktype(retries, int, "retries must be an int")
     if retries < 0:
@@ -71,7 +64,7 @@ def _connect(retries, wait):
 def _request(req, retries, wait):
     buf = json.dumps(req, indent=None) + "\n"
     # dumps returns unicode with python3, but sock requires bytes
-    if isinstance(buf, UNICODE_TYPE):
+    if isinstance(buf, str):
         buf = buf.encode("utf-8")
 
     sock = _connect(retries, wait)

--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -77,13 +77,13 @@ def _request(req, retries, wait):
     sock = _connect(retries, wait)
     sock.sendall(buf)
 
-    resp = u""
+    resp = ""
     while True:
         chunk = sock.recv(4000)
         if not chunk:
             raise Exception("no data")
         resp += chunk.decode("utf-8")
-        if resp.endswith(u"\n"):
+        if resp.endswith("\n"):
             break
 
     d = json.loads(resp[:-1])

--- a/daemon/globus_cw_daemon/config.py
+++ b/daemon/globus_cw_daemon/config.py
@@ -28,7 +28,7 @@ def get_string(key):
     try:
         return _get_config().get("general", key)
     except configparser.NoOptionError:
-        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
+        raise KeyError(f"key {key} not found in {CONFIG_PATH}")
 
 
 def get_bool(key):
@@ -40,7 +40,7 @@ def get_bool(key):
     try:
         return _get_config().getboolean("general", key)
     except configparser.NoOptionError:
-        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
+        raise KeyError(f"key {key} not found in {CONFIG_PATH}")
 
 
 def get_int(key):
@@ -52,4 +52,4 @@ def get_int(key):
     try:
         return _get_config().getint("general", key)
     except configparser.NoOptionError:
-        raise KeyError("key %s not found in %s" % (key, CONFIG_PATH))
+        raise KeyError(f"key {key} not found in {CONFIG_PATH}")

--- a/daemon/globus_cw_daemon/cwlogs.py
+++ b/daemon/globus_cw_daemon/cwlogs.py
@@ -31,7 +31,7 @@ def _add_emf_header(request, **kwargs):
     request.headers.add_header("x-amzn-logs-format", "json/emf")
 
 
-class Event(object):
+class Event:
     def __init__(self, timestamp, message, enforce_limit=True):
         """
         Raise: InvalidMessage if message is too long
@@ -53,7 +53,7 @@ class Event(object):
             raise InvalidMessage("message too large")
 
 
-class _Batch(object):
+class _Batch:
     def __init__(self):
         self.nr_bytes = 0
         self.records = []
@@ -95,7 +95,7 @@ class _Batch(object):
         return diff_ms >= (3600 * MAX_BATCH_RANGE_HOURS * 1000)
 
 
-class LogWriter(object):
+class LogWriter:
     def __init__(self, group_name, stream_name, aws_region=None):
         """
         Create the @stream_name if it doesn't exist.
@@ -197,8 +197,8 @@ def test():
 
     events = []
     # These just fit
-    events.append(Event(now_ms(), u"\n" * 262118))
-    events.append(Event(now_ms(), u"\u00a9" * 131059))
+    events.append(Event(now_ms(), "\n" * 262118))
+    events.append(Event(now_ms(), "\u00a9" * 131059))
 
     # Invalid utf8
     # events.append(Event(now_ms(), "\xff\xff"))

--- a/daemon/globus_cw_daemon/daemon.py
+++ b/daemon/globus_cw_daemon/daemon.py
@@ -189,7 +189,7 @@ def run_request_loop(listen_sock):
         try:
             try:
                 sock, addr = listen_sock.accept()
-            except socket.error:
+            except OSError:
                 continue
             try:
                 _log.debug("accepted connection")
@@ -213,7 +213,7 @@ def main():
     addr = "\0org.globus.cwlogs"
     try:
         listen_sock.bind(addr)
-    except socket.error as e:
+    except OSError as e:
         if e.errno == errno.EADDRINUSE:
             _print("cwlogs: already running")
             return

--- a/daemon/globus_cw_daemon/local_logging.py
+++ b/daemon/globus_cw_daemon/local_logging.py
@@ -30,7 +30,7 @@ class PrintKFormatter(logging.Formatter):
             "%(name)s: %(message)s"
         )
         kwargs["datefmt"] = "%Y-%m-%d %H:%M:%S"
-        super(PrintKFormatter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def encode_level(self, record):
         # logging.handlers.SyslogHandler has an interesting note about
@@ -50,8 +50,8 @@ class PrintKFormatter(logging.Formatter):
         ]
 
     def format(self, record):
-        level = "<{}>".format(self.encode_level(record))
-        return level + super(PrintKFormatter, self).format(record)
+        level = f"<{self.encode_level(record)}>"
+        return level + super().format(record)
 
 
 def configure():

--- a/test/README
+++ b/test/README
@@ -6,4 +6,5 @@ Tests the following:
 - download from github via pip
 - install and systemd config of deamon
 - install of client
-- python2/python3 compatibility of client
+- message failure and retry handling
+- ascii and non-ascii messages

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -2,18 +2,11 @@ import sys
 
 from globus_cw_client.client import log_event
 
-try:
-    # Python 2
-    UNICODE_TYPE = unicode
-except NameError:
-    # Python 3
-    UNICODE_TYPE = str
-
 
 def main():
     print("client_test.py")
 
-    print("  simple ascii test, confirms ascii str works for python2 and 3")
+    print("  simple ascii test")
     log_event("Hello world from python%d!" % sys.version_info[0])
 
     print("  non ascii bytes test")
@@ -27,7 +20,7 @@ def main():
 
     print("  non ascii unicode test")
     unicode_string = byte_string.decode("utf-8").replace("bytes", "unicode")
-    assert isinstance(unicode_string, UNICODE_TYPE)
+    assert isinstance(unicode_string, str)
     log_event(unicode_string)
 
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,7 +5,7 @@
 
 cd "$(dirname "$0")"
 
-# get a branch to test or default to master
+# get a branch to test or default to local repo
 if [ $# -eq 1 ]
 then
   branch=$1
@@ -22,13 +22,7 @@ set -ex
 # cleanup any existing daemon or venv and (re)install as root
 ./_install_daemon.sh "$daemon_installpath"
 
-# run client_test.py with python2
-virtualenv venv
-venv/bin/pip install "$client_installpath"
-venv/bin/python client_test.py
-rm -rf venv
-
-# run client_test.py with python3
+# run client_test.py
 virtualenv venv --python=python3
 venv/bin/pip install "$client_installpath"
 venv/bin/python client_test.py
@@ -37,13 +31,6 @@ rm -rf venv
 # stop the daemon and run fail_test.py
 sudo service globus_cw_daemon stop
 
-# with python2
-virtualenv venv
-venv/bin/pip install "$client_installpath"
-venv/bin/python fail_test.py
-rm -rf venv
-
-# with python3
 virtualenv venv --python=python3
 venv/bin/pip install "$client_installpath"
 venv/bin/python fail_test.py


### PR DESCRIPTION
This PR is really a combination of two things:
- a linting update
- remove the last of py2 support

They dovetail nicely because this introduces pyupgrade to keep our use of modern syntax more consistent.