### PR TITLE
Close sockets to prevent `ResourceWarning`s

### DIFF
--- a/Changelog.adoc
+++ b/Changelog.adoc
@@ -2,6 +2,8 @@
 
 == Unreleased
 
+* Close instantiated sockets on connection error to prevent `ResourceWarning`s.
+
 == 1.1
 
 * Drop client support for python2

--- a/client/globus_cw_client/client.py
+++ b/client/globus_cw_client/client.py
@@ -53,6 +53,7 @@ def _connect(retries, wait):
         try:
             sock.connect(addr)
         except Exception as err:
+            sock.close()
             error = err
         else:
             return sock


### PR DESCRIPTION
Discovered this while running pytest with warnings escalated to errors in another project that uses globus-cwlogger.