### PR TITLE
Move `mypy` from pre-commit to tox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,19 +36,6 @@ repos:
       types: [python]
       exclude: ^test/.*$
       language_version: python3
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.2
-  hooks:
-    - id: mypy
-      name: "mypy client/"
-      files: client/.*$
-      types: [python]
-      language_version: python3
-    - id: mypy
-      name: "mypy daemon/"
-      files: daemon/.*$
-      types: [python]
-      language_version: python3
 - repo: local
   hooks:
     - id: shellcheck

--- a/daemon/mypy.ini
+++ b/daemon/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist =
+    mypy-client
+    mypy-daemon
+minversion = 4.0.0
+
+[testenv:mypy-{client,daemon}]
+skip_install = true
+change_dir =
+    client: {tox_root}/client
+    daemon: {tox_root}/daemon
+deps =
+    mypy
+    client: ./client
+    daemon: ./daemon
+commands =
+    client: mypy globus_cw_client {posargs}
+    daemon: mypy globus_cw_daemon {posargs}
+    daemon: mypy globus_cw_daemon_install {posargs}


### PR DESCRIPTION
In order to run `mypy` accurately, it needs to run in a
well-constructed environment.

For now, this is done with a top-level `tox.ini` which dispatches over
the two packages.
