### PR TITLE
Add initial globus-cw-client tests

### DIFF
--- a/client/test/conftest.py
+++ b/client/test/conftest.py
@@ -1,0 +1,11 @@
+import unittest.mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_socket():
+    mock_socket = unittest.mock.Mock()
+    mock_connect = unittest.mock.Mock(return_value=mock_socket)
+    with unittest.mock.patch("globus_cw_client.client._connect", mock_connect):
+        yield mock_socket

--- a/client/test/test_log_bad_event.py
+++ b/client/test/test_log_bad_event.py
@@ -1,0 +1,9 @@
+import pytest
+
+from globus_cw_client.client import log_event
+
+
+@pytest.mark.parametrize("message", (object(), {"foo": "bar"}))
+def test_log_event_rejects_bad_message_type(message):
+    with pytest.raises(TypeError, match="must be bytes or unicode"):
+        log_event(message)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,18 @@
 envlist =
     mypy-client
     mypy-daemon
+    py{36,37,38,39,310,311,312}
+skip_missing_interpreters = true
 minversion = 4.0.0
+
+# default testenv is for the client tests
+[testenv]
+change_dir = {tox_root}/client
+skip_install = true
+deps =
+    {tox_root}/client
+    pytest
+commands = pytest {posargs}
 
 [testenv:mypy-{client,daemon}]
 skip_install = true


### PR DESCRIPTION
Runnable via tox; this introduces nearly the most minimal test rigging
possible for the client. The initial test added is a single TypeError
check.
