### PR TITLE
Add a changelog fragment for post-1.2 changes

### DIFF
--- a/changelog.d/20240828_174019_kurtmckee_changes.md
+++ b/changelog.d/20240828_174019_kurtmckee_changes.md
@@ -1,0 +1,18 @@
+### Python support
+
+- Drop support for Python 3.6 and 3.7.
+- Support Python 3.8+ and higher.
+
+### Changed
+
+- Use `orjson` for speed.
+
+### Development
+
+- Introduce a test suite.
+- Add CI to test the project.
+- Add CD to build and publish the project.
+- Use Dependabot to maintain CI/CD action versions.
+- Update pre-commit hooks.
+- Use pre-commit.ci to maintain pre-commit hook versions,
+  and to run hooks against incoming PRs.


### PR DESCRIPTION
### Python support

- Drop support for Python 3.6 and 3.7.
- Support Python 3.8+ and higher.

### Changed

- Use `orjson` for speed.

### Development

- Introduce a test suite.
- Add CI to test the project.
- Add CD to build and publish the project.
- Use Dependabot to maintain CI/CD action versions.
- Update pre-commit hooks.
- Use pre-commit.ci to maintain pre-commit hook versions,
  and to run hooks against incoming PRs.
