### PR TITLE
Add docs and tooling for release updates

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -32,11 +32,3 @@ Linting & Testing
 NOTE: Please do not reformat code cosmetically without discussing it
 beforehand. We do want to apply some code checkers and fixers, but as part of
 a carefully considered effort.
-
-
-Running a Release
------------------
-
-- Update the changelog to reflect the latest released version.
-- Cut a release branch (e.g. `release/beta-4`)
-- Notify via email that there's a new release, link to latest changelog

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+CLIENT_VERSION=$(shell grep 'version=' client/setup.py | grep -Eo '([[:digit:]]|\.)+')
+DAEMON_VERSION=$(shell grep 'version=' daemon/setup.py | grep -Eo '([[:digit:]]|\.)+')
+
 .PHONY: help
 help:
 	@echo "These are our make targets and what they do."
@@ -19,3 +22,14 @@ lint: .venv
 .PHONY: clean
 clean:
 	rm -rf .venv
+
+.PHONY: showvars tag-release prepare-release
+showvars:
+	@echo "VERSION=$(CLIENT_VERSION)"
+	@echo "CLIENT_VERSION=$(CLIENT_VERSION)"
+	@echo "DAEMON_VERSION=$(DAEMON_VERSION)"
+prepare-release:
+	tox -e prepare-release
+tag-release:
+	git tag -s "$(CLIENT_VERSION)" -m "v$(CLIENT_VERSION)"
+	-git push $(shell git rev-parse --abbrev-ref @{push} | cut -d '/' -f1) refs/tags/$(CLIENT_VERSION)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,21 @@
+# Releasing Guide
+
+- Create a release branch, `release-YY.N` (see the [versioning section](#versioning))
+- Update the version numbers in `client/setup.py` and `daemon/setup.py`
+- Update the changelog, `make prepare-release`
+- Add & commit these changes
+
+        git add CHANGELOG.md changelog.d client/setup.py daemon/setup.py
+        git commit -m 'Update version and changelog for release'
+
+- Open a release PR, `gh pr create`
+- Merge the release PR (after approval)
+- Tag the release, `make tag-release`
+- Create a GitHub release, `gh release create`
+
+## Versioning
+
+As of 2024-08-28, globus-cwlogger uses a simple CalVer variant.
+Version numbers are a two-digit year and a release number.
+
+The first release of 2025 is `25.1`, the second one is `25.2`, and so forth.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing Guide
 
-- Create a release branch, `release-YY.N` (see the [versioning section](#versioning))
+- Create a release branch, `release-X.Y.Z`
 - Update the version numbers in `client/setup.py` and `daemon/setup.py`
 - Update the changelog, `make prepare-release`
 - Add & commit these changes
@@ -15,7 +15,4 @@
 
 ## Versioning
 
-As of 2024-08-28, globus-cwlogger uses a simple CalVer variant.
-Version numbers are a two-digit year and a release number.
-
-The first release of 2025 is `25.1`, the second one is `25.2`, and so forth.
+globus-cwlogger uses SemVer.

--- a/changelog.d/20240828_221132_sirosen_update_release_methodology.md
+++ b/changelog.d/20240828_221132_sirosen_update_release_methodology.md
@@ -3,7 +3,10 @@
 - Release artifacts published in GitHub releases now use the full dist
   filenames, and include both wheel and sdist variants.
 
+- In order to synchronize versions between the client and daemon, the version
+  number has increased to 3.0.0
+
 ### Development
 
-- `globus-cwlogger` has switched to using CalVer based versioning
+- `globus-cwlogger` has switched to using SemVer based versioning.
 - There is a new release guide in `RELEASING.md`

--- a/changelog.d/20240828_221132_sirosen_update_release_methodology.md
+++ b/changelog.d/20240828_221132_sirosen_update_release_methodology.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Release artifacts published in GitHub releases now use the full dist
+  filenames, and include both wheel and sdist variants.
+
+### Development
+
+- `globus-cwlogger` has switched to using CalVer based versioning
+- There is a new release guide in `RELEASING.md`

--- a/client/setup.py
+++ b/client/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="globus_cw_client",
-    version="24.1",
+    version="3.0.0",
     packages=find_packages(),
     # descriptive info, non-critical
     description="Client for Globus CloudWatch Logger",

--- a/client/setup.py
+++ b/client/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="globus_cw_client",
-    version="1.2",
+    version="24.1",
     packages=find_packages(),
     # descriptive info, non-critical
     description="Client for Globus CloudWatch Logger",

--- a/daemon/setup.py
+++ b/daemon/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="globus_cw_daemon",
-    version="2.2",
+    version="24.1",
     packages=find_packages(),
     install_requires=["boto3<2"],
     entry_points={

--- a/daemon/setup.py
+++ b/daemon/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="globus_cw_daemon",
-    version="24.1",
+    version="3.0.0",
     packages=find_packages(),
     install_requires=["boto3<2"],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -46,3 +46,8 @@ commands =
     client: mypy globus_cw_client {posargs}
     daemon: mypy globus_cw_daemon {posargs}
     daemon: mypy globus_cw_daemon_install {posargs}
+
+[testenv:prepare-release]
+skip_install = true
+deps = scriv[toml]
+commands = scriv collect


### PR DESCRIPTION
- Add a `prepare-release` tox env for `scriv collect` invocation
- Add make targets for showing versions, tagging, and invoking tox
- Move release documentation into RELEASING.md and expand it with more detail
- Officially (per RELEASING.md) switch over to SemVer for versions
- Update versions to `3.0.0`