### PR TITLE
Add async interface for log_event in client

### DIFF
--- a/client/test/test_log_bad_event.py
+++ b/client/test/test_log_bad_event.py
@@ -4,7 +4,7 @@ from globus_cw_client.client import log_event
 
 @pytest.mark.parametrize("message", (object(), {"foo": "bar"}))
 def test_log_event_rejects_bad_message_type(message):
-    with pytest.raises(TypeError, match="must be bytes or unicode"):
+    with pytest.raises(TypeError, match="must be bytes or str"):
         log_event(message)
 
 

--- a/daemon/globus_cw_daemon/daemon.py
+++ b/daemon/globus_cw_daemon/daemon.py
@@ -208,8 +208,16 @@ def main():
     _print("cwlogs: starting...")
     _log.info("starting")
 
+    addr = "/tmp/org.globus.cwlogs"
+
+    # clean up previous socket if exists
+    try:
+        os.remove(addr)
+    except FileNotFoundError:
+        pass
+
+    os.umask(0)
     listen_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, 0)
-    addr = "\0org.globus.cwlogs"
     try:
         listen_sock.bind(addr)
     except OSError as e:


### PR DESCRIPTION
Transfer needs an async interface.  Transfer is using UvicornWorker.  UvicornWorker uses uvloop for performance.  uvloop has a bug with abstract unix sockets so part of this is changing the client and daemon to use a non-virtual unix socket.